### PR TITLE
Removing repos copy, using pushover fork that works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ RUN apt-get update && apt-get -y install cron vim
 
 WORKDIR /github/app
 COPY ./app /github/app
-COPY ./repos /github/repos
-COPY ./logs /github/logs
 
 RUN pip install -r requirements.txt
 COPY crontab /etc/cron.d/github_backup

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,4 @@
 PyGithub
 GitPython
-python-pushover
+git+https://github.com/SmileyJoe/python-pushover@v0.4#egg=python-pushover
 pyyaml


### PR DESCRIPTION
- Copying the repos directory caused changes to not reflect outside the container
- python-pushover is no longer mainted and has a requirement on 2to3 which is no longer available. Move to using a branch on a fork that is rolled back to the same version, but removes the requirement on 2to3